### PR TITLE
登録情報の削除

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,5 @@
 class ProductsController < ApplicationController
-  before_action :authenticate_user!, only: [:new,:edit]
+  before_action :authenticate_user!, only: [:new, :edit]
   before_action :set_product, only: [:edit, :show, :update, :destroy]
   before_action :move_to_index, except: [:index, :show, :new, :create]
 
@@ -34,6 +34,11 @@ class ProductsController < ApplicationController
     end
   end
 
+  def destroy
+    @product.destroy
+    redirect_to root_path
+  end
+
   private
 
   def product_params
@@ -46,6 +51,6 @@ class ProductsController < ApplicationController
   end
 
   def move_to_index
-    redirect_to action: :index unless (current_user.id == @product.user_id)
+    redirect_to action: :index unless current_user.id == @product.user_id
   end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,5 @@
 class ProductsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :edit]
+  before_action :authenticate_user!, only: [:new, :edit, :destroy]
   before_action :set_product, only: [:edit, :show, :update, :destroy]
   before_action :move_to_index, except: [:index, :show, :new, :create]
 

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -28,7 +28,7 @@
 
     <%= link_to "商品の編集", edit_product_path, method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+    <%= link_to "削除", product_path, method: :delete, class:"item-destroy" %>
 
     <% elsif user_signed_in? && (current_user.id != @product.user_id)   %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to: "products#index"
-  resources :products, only: [:index, :new, :create, :show, :edit, :update ]
+  resources :products
 
 end
   


### PR DESCRIPTION
What  
・商品削除機能を実装  
Why  
・商品削除機能  
　商品情報を削除できるようになること 
画像・動画 
ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/2bf6f90ab9f8f455b0fe435b3978751c